### PR TITLE
RHMAP-12150 README.md update with doc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git push origin {TAG}
 
 ### c) Generate API Documentation
 
-To generate API documentation and sync with the [GitHub pages placeholder](http://feedhenry.github.io/fh-ios-sdk/FH/docset/Contents/Resources/Documents/index.html), switch to ['gh-pages'](https://github.com/feedhenry/fh-ios-sdk/tree/gh-pages) branch and follow the instructions there.
+To generate API documentation and sync with the [GitHub pages placeholder](http://feedhenry.github.io/fh-ios-swift-sdk/FeedHenry/docset/index.html), switch to ['gh-pages'](https://github.com/feedhenry/fh-ios-swift-sdk/tree/gh-pages) branch and follow the instructions there.
 
 ## Usage
 


### PR DESCRIPTION
gh-pages doesn't exist right now in feedhenry repo, we have to [review my branch first](https://github.com/jcesarmobile/fh-ios-swift-sdk/tree/gh-pages) and push the content feedhenry repo.
Once that is done we can review and merge this PR

[Preview of the docs 
](https://jcesarmobile.github.io/fh-ios-swift-sdk/FeedHenry/docset/index.html)