### PR TITLE
RHMAP-13495 PushStarter template crashes on iOS9 if push is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG - FeedHenry iOS SDK
 
+### 5.0.3 - 2017-02-22
+* RHMAP-13495: PushStarter template crashes on iOS9 if push is not enabled
+
 ### 5.0.2 - 2017-01-10
 * RHMAP-12362: Push notifications doesn't work with alias
 

--- a/FeedHenry.podspec
+++ b/FeedHenry.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FeedHenry'
-  s.version      = '5.0.2'
+  s.version      = '5.0.3'
   s.summary      = 'FeedHenry Swift iOS Software Development Kit'
   s.homepage     = 'https://www.feedhenry.com'
   s.social_media_url = 'https://twitter.com/feedhenry'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.module_map = 'FeedHenry/module.modulemap'
   s.requires_arc = true
   s.dependency 'AeroGearHttp', '1.0.0'
-  s.dependency 'AeroGear-Push-Swift', '2.0.0'
+  s.dependency 'AeroGear-Push-Swift', '2.0.1'
   s.dependency 'ReachabilitySwift', '3'
 end

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ use_frameworks!
 target 'FeedHenry' do
 	pod 'AeroGearHttp', '1.0.0'
 	pod 'ReachabilitySwift', '3'
-	pod 'AeroGear-Push-Swift', '2.0.0'
+	pod 'AeroGear-Push-Swift', '2.0.1'
 
 	target 'FeedHenryTests' do
 		pod 'OHHTTPStubs', '5.2.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AeroGear-Push-Swift (2.0.0)
+  - AeroGear-Push-Swift (2.0.1)
   - AeroGearHttp (1.0.0)
   - OCMock (3.3.1)
   - OHHTTPStubs (5.2.2):
@@ -20,7 +20,7 @@ PODS:
   - ReachabilitySwift (3)
 
 DEPENDENCIES:
-  - AeroGear-Push-Swift (= 2.0.0)
+  - AeroGear-Push-Swift (= 2.0.1)
   - AeroGearHttp (= 1.0.0)
   - OCMock (= 3.3.1)
   - OHHTTPStubs (= 5.2.2)
@@ -28,12 +28,12 @@ DEPENDENCIES:
   - ReachabilitySwift (= 3)
 
 SPEC CHECKSUMS:
-  AeroGear-Push-Swift: 5068f6f4057da4fa49d3592bf75a63d0916200ff
+  AeroGear-Push-Swift: 6a908913d0176de953451d254d508355d3d3bb61
   AeroGearHttp: 8c825d4563439f565196f52efe80e15f0055109a
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OHHTTPStubs: 34d9d0994e64fcf8552dbfade5ce82ada913ee31
   ReachabilitySwift: f5b9bb30a0777fac8f09ce8b067e32faeb29bb64
 
-PODFILE CHECKSUM: 995cddc4dbeef42b4015c13ea792c96159b04cee
+PODFILE CHECKSUM: acbd1706baa9b0b61d4022aee38335a8d8ef7355
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
Bumped version of AeroGear-Push-Swift to 2.0.1 as the issue was fixed there