### PR TITLE
Move from coverage to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Maintenance](https://img.shields.io/maintenance/yes/2017.svg)
 [![circle-ci](https://img.shields.io/circleci/project/github/feedhenry/fh-ios-swift-sdk/master.svg)](https://circleci.com/gh/feedhenry/fh-ios-swift-sdk)
-[![Coverage Status](https://coveralls.io/repos/github/feedhenry/fh-ios-swift-sdk/badge.svg?branch=master)](https://coveralls.io/github/feedhenry/fh-ios-swift-sdk?branch=master)
+[![Codecov](https://img.shields.io/codecov/c/github/codecov/fh-ios-swift-sdk/master.svg)](https://codecov.io/gh/feedhenry/fh-ios-swift-sdk)
 [![License](https://img.shields.io/badge/-Apache%202.0-blue.svg)](https://opensource.org/s/Apache-2.0)
 [![GitHub release](https://img.shields.io/github/release/feedhenry/fh-ios-swift-sdk.svg)](https://github.com/feedhenry/fh-ios-swift-sdk/releases)
 [![CocoaPods](https://img.shields.io/cocoapods/v/FeedHenry.svg)](https://cocoapods.org/pods/FeedHenry)

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     XCODE_WORKSPACE: "FeedHenry.xcworkspace"
     XCODE_SCHEME: "FeedHenry"
     SIMULATOR: "iPhone 7"
-    OS: "11.0"
+    OS: "11.0.1"
 
 general:
   branches:
@@ -26,3 +26,6 @@ test:
         clean build test |
       tee $CIRCLE_ARTIFACTS/xcode_raw.log |
       xcpretty --color --report junit --output $CIRCLE_TEST_REPORTS/xcode/results.xml
+  
+  post: 
+    - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Related issues:

* [FH-4315](https://issues.jboss.org/browse/FH-4315) - Move fh-ios-swift-sdk from Coveralls to Codecov 